### PR TITLE
Skip trying to deploy dependabot PRs

### DIFF
--- a/.github/workflows/create-template.yml
+++ b/.github/workflows/create-template.yml
@@ -7,6 +7,7 @@ on:
       - "main"
       - "master"
       - "dev*"
+      - "dependabot*"
 
 jobs:
   build:


### PR DESCRIPTION
We really don't want to be trying to create hackpads in response to dependabot PRs.